### PR TITLE
PE-40218 Fix nexus-wait-for-rpm-repomd

### DIFF
--- a/bin/nexus-wait-for-rpm-repomd
+++ b/bin/nexus-wait-for-rpm-repomd
@@ -16,7 +16,7 @@ echo >&2 "Waiting for Nexus to create repository metadata for ${reponame}..."
 
 # Note the use of NEXUS_URL as opposed to URL since this NOT using a REST API
 # endpoint.
-while ! curl -Isf "${NEXUS_URL}/repository/${reponame}/repodata/repomd.xml" ; do
+while ! curl -Isfk "${NEXUS_URL}/repository/${reponame}/repodata/repomd.xml" ; do
     echo >&2 "${reponame} repo metadata is not ready yet..."
     sleep "$interval"
 done


### PR DESCRIPTION
## Summary and Scope

The nexus-wait-for-rpm-repomd was failing, since curl was failing with
exit code 60 (certificate authentication error). Add -k ignore the
certificate error, consistent with other curl calls here.

## Issues and Related PRs

* Part of PE-40218

## Testing

### Tested on:

  * hela

### Test description:

Manually tested.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

